### PR TITLE
remove app version question

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -26,6 +26,14 @@ body:
       value: "A bug happened!"
     validations:
       required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: ex. 2.6.10
+    validations:
+      required: true
   - type: dropdown
     id: android
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -27,15 +27,6 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: version
-    attributes:
-      label: Version
-      description: What version of our software are you running?
-      options:
-        - 2.6.9 (Newest)
-    validations:
-      required: true
-  - type: dropdown
     id: android
     attributes:
       label: What android version are you seeing the problem on?

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -61,7 +61,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/wagyufari/dzikirqu-android)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dzikirqu/.github/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true


### PR DESCRIPTION
The App version is unnecessary because we assume users always use the newest version of our app.