### PR TITLE
Support full height share

### DIFF
--- a/app/src/main/java/com/wagyufari/dzikirqu/util/ViewUtils.kt
+++ b/app/src/main/java/com/wagyufari/dzikirqu/util/ViewUtils.kt
@@ -40,10 +40,10 @@ object ViewUtils {
         return (dp * Resources.getSystem().displayMetrics.density)
     }
 
-    fun getBitmapFromView(view: View): Bitmap {
+    fun getBitmapFromView(view: View, width: Int = view.width, height: Int = view.height): Bitmap {
         //Define a bitmap with the same size as the view
         val returnedBitmap: Bitmap =
-            Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
+            Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
         //Bind a canvas to it
         val canvas = Canvas(returnedBitmap)
         //Get the view's background

--- a/app/src/main/res/layout/activity_share_image.xml
+++ b/app/src/main/res/layout/activity_share_image.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -9,9 +11,7 @@
 
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".ui.share.ShareImageActivity">
@@ -64,121 +64,130 @@
                     app:layout_constraintDimensionRatio="1:1"
                     app:layout_constraintTop_toTopOf="parent">
 
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/image"
+                    <androidx.core.widget.NestedScrollView
+                        android:id="@+id/imageContainer"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
-                        android:background="@drawable/radial"
-                        android:orientation="vertical"
-                        app:layout_constraintDimensionRatio="1:1">
+                        android:fillViewport="true">
 
-                        <ImageView
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/image"
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"
-                            android:alpha="0.2"
-                            android:src="@drawable/ic_subtract_3" />
-
-                        <LinearLayout
-                            android:id="@+id/logo"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginTop="24dp"
-                            android:gravity="center_vertical"
-                            android:orientation="horizontal"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toTopOf="parent">
+                            android:background="@drawable/radial"
+                            android:orientation="vertical"
+                            app:layout_constraintDimensionRatio="1:1">
 
                             <ImageView
-                                android:layout_width="24dp"
-                                android:layout_height="24dp"
-                                android:padding="2dp"
-                                android:src="@drawable/ic_dzikir"
-                                app:tint="@color/white" />
+                                android:layout_width="match_parent"
+                                android:layout_height="match_parent"
+                                android:alpha="0.2"
+                                android:src="@drawable/ic_subtract_3" />
 
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="20dp"
-                                android:layout_marginStart="2dp"
-                                android:fontFamily="@font/gideon"
-                                android:text="DzikirQu"
-                                android:textColor="@color/white"
-                                android:textSize="16sp" />
-
-                        </LinearLayout>
-
-                        <LinearLayout
-                            android:layout_width="match_parent"
-                            android:layout_height="0dp"
-                            android:gravity="center"
-                            android:orientation="vertical"
-                            app:layout_constraintBottom_toTopOf="@id/play"
-                            app:layout_constraintTop_toBottomOf="@id/logo">
-
-                            <TextView
-                                android:id="@+id/titleText"
+                            <LinearLayout
+                                android:id="@+id/logo"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
                                 android:layout_marginTop="24dp"
-                                android:fontFamily="@font/regular"
-                                android:textAlignment="center"
-                                android:text="Do'a Berbuka Puasa"
-                                android:textColor="@color/white"
-                                android:textSize="16sp" />
+                                android:gravity="center_vertical"
+                                android:orientation="horizontal"
+                                app:layout_constraintLeft_toLeftOf="parent"
+                                app:layout_constraintRight_toRightOf="parent"
+                                app:layout_constraintTop_toTopOf="parent">
 
-                            <TextView
-                                android:id="@+id/arabic"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="24dp"
-                                android:layout_marginEnd="24dp"
-                                android:ellipsize="end"
-                                android:fontFamily="@font/al_qalam"
-                                android:maxLines="5"
-                                android:text="يَٰٓأَيُّهَا ٱلَّذِينَ ءَامَنُوٓا۟ إِذَا تَدَايَنتُم بِدَيْنٍ إِلَىٰٓ أَجَلٍ مُّسَمًّى فَٱكْتُبُوهُ ۚ وَلْيَكْتُب بَّيْنَكُمْ كَاتِبُۢ بِٱلْعَدْلِ ۚ وَلَا يَأْبَ كَاتِبٌ أَن يَكْتُبَ كَمَا عَلَّمَهُ ٱللَّهُ ۚ فَلْيَكْتُبْ وَلْيُمْلِلِ ٱلَّذِى عَلَيْهِ ٱلْحَقُّ وَلْيَتَّقِ ٱللَّهَ رَبَّهُۥ وَلَا يَبْخَسْ مِنْهُ شَيْـًٔا ۚ فَإِن كَانَ ٱلَّذِى عَلَيْهِ ٱلْحَقُّ سَفِيهًا أَوْ ضَعِيفًا أَوْ لَا يَسْتَطِيعُ أَن يُمِلَّ هُوَ فَلْيُمْلِلْ وَلِيُّهُۥ بِٱلْعَدْلِ ۚ وَٱسْتَشْهِدُوا۟ شَهِيدَيْنِ مِن رِّجَالِكُمْ ۖ فَإِن لَّمْ يَكُونَا رَجُلَيْنِ فَرَجُلٌ وَٱمْرَأَتَانِ مِمَّن تَرْضَوْنَ مِنَ ٱلشُّهَدَآءِ أَن تَضِلَّ إِحْدَىٰهُمَا فَتُذَكِّرَ إِحْدَىٰهُمَا ٱلْأُخْرَىٰ ۚ وَلَا يَأْبَ ٱلشُّهَدَآءُ إِذَا مَا دُعُوا۟ ۚ وَلَا تَسْـَٔمُوٓا۟ أَن تَكْتُبُوهُ صَغِيرًا أَوْ كَبِيرًا إِلَىٰٓ أَجَلِهِۦ ۚ ذَٰلِكُمْ أَقْسَطُ عِندَ ٱللَّهِ وَأَقْوَمُ لِلشَّهَٰدَةِ وَأَدْنَىٰٓ أَلَّا تَرْتَابُوٓا۟ ۖ إِلَّآ أَن تَكُونَ تِجَٰرَةً حَاضِرَةً تُدِيرُونَهَا بَيْنَكُمْ فَلَيْسَ عَلَيْكُمْ جُنَاحٌ أَلَّا تَكْتُبُوهَا ۗ وَأَشْهِدُوٓا۟ إِذَا تَبَايَعْتُمْ ۚ وَلَا يُضَآرَّ كَاتِبٌ وَلَا شَهِيدٌ ۚ وَإِن تَفْعَلُوا۟ فَإِنَّهُۥ فُسُوقُۢ بِكُمْ ۗ وَٱتَّقُوا۟ ٱللَّهَ ۖ وَيُعَلِّمُكُمُ ٱللَّهُ ۗ وَٱللَّهُ بِكُلِّ شَىْءٍ عَلِيمٌ"
-                                android:textAlignment="center"
-                                android:textColor="@color/white"
-                                android:textSize="24sp" />
+                                <ImageView
+                                    android:layout_width="24dp"
+                                    android:layout_height="24dp"
+                                    android:padding="2dp"
+                                    android:src="@drawable/ic_dzikir"
+                                    app:tint="@color/white" />
 
-                            <TextView
-                                android:id="@+id/translation"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="24dp"
-                                android:layout_marginTop="8dp"
-                                android:layout_marginEnd="24dp"
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="20dp"
+                                    android:layout_marginStart="2dp"
+                                    android:fontFamily="@font/gideon"
+                                    android:text="DzikirQu"
+                                    android:textColor="@color/white"
+                                    android:textSize="16sp" />
+
+                            </LinearLayout>
+
+                            <LinearLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="0dp"
+                                android:gravity="center"
+                                android:orientation="vertical"
+                                app:layout_constraintBottom_toTopOf="@id/play"
+                                app:layout_constraintTop_toBottomOf="@id/logo">
+
+                                <TextView
+                                    android:id="@+id/titleText"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="24dp"
+                                    android:fontFamily="@font/regular"
+                                    android:textAlignment="center"
+                                    android:text="Do'a Berbuka Puasa"
+                                    android:textColor="@color/white"
+                                    android:textSize="16sp" />
+
+                                <TextView
+                                    android:id="@+id/arabic"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="24dp"
+                                    android:layout_marginEnd="24dp"
+                                    android:ellipsize="end"
+                                    android:fontFamily="@font/al_qalam"
+                                    android:maxLines="5"
+                                    android:text="يَٰٓأَيُّهَا ٱلَّذِينَ ءَامَنُوٓا۟ إِذَا تَدَايَنتُم بِدَيْنٍ إِلَىٰٓ أَجَلٍ مُّسَمًّى فَٱكْتُبُوهُ ۚ وَلْيَكْتُب بَّيْنَكُمْ كَاتِبُۢ بِٱلْعَدْلِ ۚ وَلَا يَأْبَ كَاتِبٌ أَن يَكْتُبَ كَمَا عَلَّمَهُ ٱللَّهُ ۚ فَلْيَكْتُبْ وَلْيُمْلِلِ ٱلَّذِى عَلَيْهِ ٱلْحَقُّ وَلْيَتَّقِ ٱللَّهَ رَبَّهُۥ وَلَا يَبْخَسْ مِنْهُ شَيْـًٔا ۚ فَإِن كَانَ ٱلَّذِى عَلَيْهِ ٱلْحَقُّ سَفِيهًا أَوْ ضَعِيفًا أَوْ لَا يَسْتَطِيعُ أَن يُمِلَّ هُوَ فَلْيُمْلِلْ وَلِيُّهُۥ بِٱلْعَدْلِ ۚ وَٱسْتَشْهِدُوا۟ شَهِيدَيْنِ مِن رِّجَالِكُمْ ۖ فَإِن لَّمْ يَكُونَا رَجُلَيْنِ فَرَجُلٌ وَٱمْرَأَتَانِ مِمَّن تَرْضَوْنَ مِنَ ٱلشُّهَدَآءِ أَن تَضِلَّ إِحْدَىٰهُمَا فَتُذَكِّرَ إِحْدَىٰهُمَا ٱلْأُخْرَىٰ ۚ وَلَا يَأْبَ ٱلشُّهَدَآءُ إِذَا مَا دُعُوا۟ ۚ وَلَا تَسْـَٔمُوٓا۟ أَن تَكْتُبُوهُ صَغِيرًا أَوْ كَبِيرًا إِلَىٰٓ أَجَلِهِۦ ۚ ذَٰلِكُمْ أَقْسَطُ عِندَ ٱللَّهِ وَأَقْوَمُ لِلشَّهَٰدَةِ وَأَدْنَىٰٓ أَلَّا تَرْتَابُوٓا۟ ۖ إِلَّآ أَن تَكُونَ تِجَٰرَةً حَاضِرَةً تُدِيرُونَهَا بَيْنَكُمْ فَلَيْسَ عَلَيْكُمْ جُنَاحٌ أَلَّا تَكْتُبُوهَا ۗ وَأَشْهِدُوٓا۟ إِذَا تَبَايَعْتُمْ ۚ وَلَا يُضَآرَّ كَاتِبٌ وَلَا شَهِيدٌ ۚ وَإِن تَفْعَلُوا۟ فَإِنَّهُۥ فُسُوقُۢ بِكُمْ ۗ وَٱتَّقُوا۟ ٱللَّهَ ۖ وَيُعَلِّمُكُمُ ٱللَّهُ ۗ وَٱللَّهُ بِكُلِّ شَىْءٍ عَلِيمٌ"
+                                    android:textAlignment="center"
+                                    android:textColor="@color/white"
+                                    android:textSize="24sp" />
+
+                                <TextView
+                                    android:id="@+id/translation"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="24dp"
+                                    android:layout_marginTop="8dp"
+                                    android:layout_marginEnd="24dp"
+                                    android:layout_marginBottom="16dp"
+                                    android:ellipsize="end"
+                                    android:fontFamily="@font/regular"
+                                    android:maxLines="5"
+                                    android:text="Say, ˹O Prophet, that Allah says,˺ “O My servants who have exceeded the limits against their souls! Do not lose hope in Allah’s mercy, for Allah certainly forgives all sins. He is indeed the All-Forgiving, Most Merciful."
+                                    android:textAlignment="center"
+                                    android:textColor="@color/white" />
+
+                                <TextView
+                                    android:id="@+id/source"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="24dp"
+                                    android:layout_marginEnd="24dp"
+                                    android:fontFamily="@font/regular"
+                                    android:text="Al-Fatiha"
+                                    android:textAlignment="center"
+                                    android:textColor="@color/white" />
+
+                            </LinearLayout>
+
+                            <ImageView
+                                android:id="@+id/play"
+                                android:layout_width="100dp"
+                                android:layout_height="30dp"
                                 android:layout_marginBottom="16dp"
-                                android:ellipsize="end"
-                                android:fontFamily="@font/regular"
-                                android:maxLines="5"
-                                android:text="Say, ˹O Prophet, that Allah says,˺ “O My servants who have exceeded the limits against their souls! Do not lose hope in Allah’s mercy, for Allah certainly forgives all sins. He is indeed the All-Forgiving, Most Merciful."
-                                android:textAlignment="center"
-                                android:textColor="@color/white" />
+                                android:src="@drawable/get_it_googleplay"
+                                app:layout_constraintBottom_toBottomOf="parent"
+                                app:layout_constraintLeft_toLeftOf="parent"
+                                app:layout_constraintRight_toRightOf="parent" />
 
-                            <TextView
-                                android:id="@+id/source"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="24dp"
-                                android:layout_marginEnd="24dp"
-                                android:fontFamily="@font/regular"
-                                android:text="Al-Fatiha"
-                                android:textAlignment="center"
-                                android:textColor="@color/white" />
+                        </androidx.constraintlayout.widget.ConstraintLayout>
 
-                        </LinearLayout>
+                    </androidx.core.widget.NestedScrollView>
 
-                        <ImageView
-                            android:id="@+id/play"
-                            android:layout_width="100dp"
-                            android:layout_height="30dp"
-                            android:layout_marginBottom="16dp"
-                            android:src="@drawable/get_it_googleplay"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintRight_toRightOf="parent" />
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
                 </com.google.android.material.card.MaterialCardView>
 
                 <LinearLayout


### PR DESCRIPTION
## What kind of change does this PR introduce?

To support full height heigh share when the content overflows the view size

## What is the current behavior?

The current behavior is done by clipping the text

![image](https://user-images.githubusercontent.com/9760691/183806433-cefa26e2-e3f1-426c-ab98-86a720718409.png)

## What is the new behavior?

The full height share is achieved by wrapping the content with NestedScrollView so the full height view can be captured

![image](https://user-images.githubusercontent.com/9760691/183806749-e4377cac-c369-49b0-bd45-656a68ad9336.png)

**I removed the play store image here**

## Others

Additionally, I think its best to just remove the **Download from Google Play** since it would be annoying. Showing a logo is fine, but showing **Download from Google Play** looks weird.